### PR TITLE
Change template dockerfiles to use official node base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/ibmnode
+FROM node:8-stretch
 
 WORKDIR "/app"
 

--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -1,4 +1,4 @@
-FROM ibmcom/ibmnode
+FROM node:8-stretch
 
 ENV PORT 3000
 


### PR DESCRIPTION
We are required to move from ibmcom/ibmnode to official node images. This updates our node template project to use the same base image as the yeoman generated projects, i.e. node 8 on latest stable level of debian ('stretch', see https://www.debian.org/releases/).